### PR TITLE
Fix README.md appearing in site content

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -18,7 +18,9 @@
       "Bash(gh pr diff:*)",
       "Bash(mv:*)",
       "Bash(gh pr close:*)",
-      "Bash(gh pr list:*)"
+      "Bash(gh pr list:*)",
+      "Bash(pkill:*)",
+      "Bash(hugo)"
     ],
     "deny": []
   }

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -39,3 +39,9 @@ outputFormats:
 disableKinds:
   - taxonomy
   - term
+
+# Ignore files
+ignoreFiles:
+  - "^README\\.md$"
+  - "\\.git"
+  - "\\.gitignore"


### PR DESCRIPTION
- Add ignoreFiles configuration to hugo.yaml
- Exclude README.md from being processed as content
